### PR TITLE
checks issuer org

### DIFF
--- a/lib/vc.js
+++ b/lib/vc.js
@@ -245,6 +245,11 @@ async function verifyCredential(options = {}) {
  * @param {Function} [options.documentLoader]
  * @param {Function} [options.checkStatus] - Optional function for checking
  *   credential status if `credentialStatus` is present on the credential.
+ * @param {Function} [options.checkIssuer] - Optional function for checking
+ *   that an issuer is eligible to issue credentials on behalf of an org.
+ * @param {Function} [options.issuerOrg] - Optional representation of an org
+ *   on behalf of which an issuer has the authority to issue credentials.
+ *   This can be an identifier or an instance of a predefined type.
  *
  * @returns {Promise<VerifyCredentialResult>} The verification result.
  */
@@ -259,6 +264,12 @@ async function _verifyCredential(options = {}) {
     throw new TypeError(
       'A "checkStatus" function must be given to verify credentials with ' +
       '"credentialStatus".');
+  }
+
+  if(credential.issuerOrg && typeof options.checkIssuer !== 'function') {
+    throw new TypeError(
+      'A "checkIssuer" function must be given to verify credentials with ' +
+      '"issuerOrg".');
   }
 
   const documentLoader = options.documentLoader || defaultDocumentLoader;
@@ -279,6 +290,13 @@ async function _verifyCredential(options = {}) {
   if(credential.credentialStatus) {
     result.statusResult = await checkStatus(options);
     if(!result.statusResult.verified) {
+      result.verified = false;
+    }
+  }
+
+  if(credential.checkIssuer) {
+    const checkIssuerResult = await checkIssuer(options);
+    if(!checkIssuerResult.verified) {
       result.verified = false;
     }
   }


### PR DESCRIPTION
This PR accomplishes the following:
- adds `checkIssuer `function property to `verifyCredential` `options` input to enable issuer org membership checks
- adds `issuerOrg` property to `verifyCredential` `options` input representing issuer's self-proclaimed org as an identifier or other predefined type